### PR TITLE
1.4.1

### DIFF
--- a/GuysNight.LethalCompanyMod.BalancedItems/CHANGELOG.md
+++ b/GuysNight.LethalCompanyMod.BalancedItems/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Version 1.4.1
+
+This release fixes some very serious performance issues when you have other mods that add a bunch of moons and/or scrap.
+Thanks to NiranV for the report!
+
+For additional performance improvements, I recommend setting your console log level to "None" in your BepInEx.cfg file.
+Under "Logging.Console" section in your BepInEx.cfg file, set "LogLevels" to "None".
+
 # Version 1.4.0
 
 ## Added

--- a/GuysNight.LethalCompanyMod.BalancedItems/GuysNight.LethalCompanyMod.BalancedItems.csproj
+++ b/GuysNight.LethalCompanyMod.BalancedItems/GuysNight.LethalCompanyMod.BalancedItems.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>netstandard2.1</TargetFramework>
         <AssemblyName>GuysNight.LethalCompanyMod.BalancedItems</AssemblyName>
         <Description>Balance out various aspects of the items in the game by giving you control of certain properties of those items.</Description>
-        <Version>1.4.0</Version>
+        <Version>1.4.1</Version>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>
 

--- a/GuysNight.LethalCompanyMod.BalancedItems/Patches/GrabbableObjectPatches.cs
+++ b/GuysNight.LethalCompanyMod.BalancedItems/Patches/GrabbableObjectPatches.cs
@@ -20,10 +20,12 @@ namespace GuysNight.LethalCompanyMod.BalancedItems.Patches {
 			SharedComponents.Logger.LogDebug($"item.itemProperties.minValue is '{__instance.itemProperties.minValue}'");
 			SharedComponents.Logger.LogDebug($"item.itemProperties.maxValue is '{__instance.itemProperties.maxValue}'");
 
-			SharedComponents.Logger.LogDebug($"Begin adding config entries and setting override values for '{__instance.itemProperties.name}'");
+			if (!ItemsContainer.Items.TryGetValue(__instance.itemProperties.name, out var itemEntry)) {
+				//should be impossible so long we initialize the collection in StartOfRoundPatches
+				SharedComponents.Logger.LogWarning($"No item entry exists for item '{__instance.itemProperties.name}'. Making no changes to item weight.");
 
-			SharedComponents.ConfigFile.Reload();
-			var itemEntry = ConfigUtilities.SyncConfigForItemOverrides(__instance.itemProperties);
+				return;
+			}
 
 			if (bool.TryParse(SharedComponents.ConfigFile[Constants.ConfigSectionHeaderToggles, Constants.ConfigKeyToggleWeights].GetSerializedValue(), out var isWeightFeatureEnabled)) {
 				SharedComponents.Logger.LogDebug($"Successfully retrieved weight override feature toggle. Value is '{isWeightFeatureEnabled}'");
@@ -34,6 +36,10 @@ namespace GuysNight.LethalCompanyMod.BalancedItems.Patches {
 			}
 
 			if (isWeightFeatureEnabled) {
+				//retrieve latest value from config
+				SharedComponents.ConfigFile.Reload();
+				SharedComponents.Logger.LogDebug($"Begin adding config entries and setting override values for '{__instance.itemProperties.name}'");
+				itemEntry = ConfigUtilities.SyncConfigForItemOverrides(__instance.itemProperties);
 				UpdateItemWeight(__instance, itemEntry.Overrides.Weight);
 			}
 			else {

--- a/GuysNight.LethalCompanyMod.BalancedItems/Patches/GrabbableObjectPatches.cs
+++ b/GuysNight.LethalCompanyMod.BalancedItems/Patches/GrabbableObjectPatches.cs
@@ -22,6 +22,7 @@ namespace GuysNight.LethalCompanyMod.BalancedItems.Patches {
 
 			SharedComponents.Logger.LogDebug($"Begin adding config entries and setting override values for '{__instance.itemProperties.name}'");
 
+			SharedComponents.ConfigFile.Reload();
 			var itemEntry = ConfigUtilities.SyncConfigForItemOverrides(__instance.itemProperties);
 
 			if (bool.TryParse(SharedComponents.ConfigFile[Constants.ConfigSectionHeaderToggles, Constants.ConfigKeyToggleWeights].GetSerializedValue(), out var isWeightFeatureEnabled)) {

--- a/GuysNight.LethalCompanyMod.BalancedItems/Patches/RoundManagerPatches.cs
+++ b/GuysNight.LethalCompanyMod.BalancedItems/Patches/RoundManagerPatches.cs
@@ -16,6 +16,7 @@ namespace GuysNight.LethalCompanyMod.BalancedItems.Patches {
 				return;
 			}
 
+			SharedComponents.ConfigFile.Reload();
 			foreach (var spawnableScrap in __instance.currentLevel.spawnableScrap.Select(x => x.spawnableItem)) {
 				SharedComponents.Logger.LogDebug($"spawnableScrap.name is '{spawnableScrap.name}'");
 				SharedComponents.Logger.LogDebug($"spawnableScrap.itemName is '{spawnableScrap.itemName}'");

--- a/GuysNight.LethalCompanyMod.BalancedItems/Patches/RoundManagerPatches.cs
+++ b/GuysNight.LethalCompanyMod.BalancedItems/Patches/RoundManagerPatches.cs
@@ -23,10 +23,8 @@ namespace GuysNight.LethalCompanyMod.BalancedItems.Patches {
 				SharedComponents.Logger.LogDebug($"spawnableScrap.minValue is '{spawnableScrap.minValue}'");
 				SharedComponents.Logger.LogDebug($"spawnableScrap.maxValue is '{spawnableScrap.maxValue}'");
 
-				var itemEntry = ConfigUtilities.SyncConfigForItemOverrides(spawnableScrap);
-
-				if (!ItemsContainer.Items.ContainsKey(spawnableScrap.name)) {
-					//should be impossible so long as we sync with config before this check
+				if (!ItemsContainer.Items.TryGetValue(spawnableScrap.name, out var itemEntry)) {
+					//should be impossible so long we initialize the collection in StartOfRoundPatches
 					SharedComponents.Logger.LogWarning($"No item entry exists for item '{spawnableScrap.name}'. Making no changes to item value.");
 
 					continue;
@@ -41,6 +39,8 @@ namespace GuysNight.LethalCompanyMod.BalancedItems.Patches {
 				}
 
 				if (isSellValueFeatureEnabled) {
+					//retrieve latest value from config
+					itemEntry = ConfigUtilities.SyncConfigForItemOverrides(spawnableScrap);
 					UpdateItemValue(spawnableScrap, itemEntry.Overrides.MinValue, itemEntry.Overrides.MaxValue);
 				}
 				else {

--- a/GuysNight.LethalCompanyMod.BalancedItems/Patches/StartOfRoundPatches.cs
+++ b/GuysNight.LethalCompanyMod.BalancedItems/Patches/StartOfRoundPatches.cs
@@ -17,6 +17,7 @@ namespace GuysNight.LethalCompanyMod.BalancedItems.Patches {
 			}
 
 			SharedComponents.Logger.LogDebug($"Found {__instance.allItemsList.itemsList.Count} items in __instance.allItemsList.itemsList.");
+			SharedComponents.ConfigFile.Reload();
 			foreach (var item in __instance.allItemsList.itemsList.OrderBy(i => i.itemName)) {
 				SharedComponents.Logger.LogDebug("allItemsListEntry: " +
 				                                 $"name = '{item.name}', " +

--- a/GuysNight.LethalCompanyMod.BalancedItems/Patches/StartOfRoundPatches.cs
+++ b/GuysNight.LethalCompanyMod.BalancedItems/Patches/StartOfRoundPatches.cs
@@ -47,8 +47,16 @@ namespace GuysNight.LethalCompanyMod.BalancedItems.Patches {
 						isMoonRarityFeatureEnabled = true;
 					}
 
-					var itemEntry = ConfigUtilities.SyncConfigForItemRarityOverride(level, spawnableScrap);
+					if (!ItemsContainer.Items.TryGetValue(spawnableScrap.spawnableItem.name, out var itemEntry)) {
+						//should be impossible so long we initialize the collection in StartOfRoundPatches
+						SharedComponents.Logger.LogWarning($"No item entry exists for item '{spawnableScrap.spawnableItem.name}'. Making no changes to item moon rarity.");
+
+						continue;
+					}
+
 					if (isMoonRarityFeatureEnabled) {
+						//retrieve latest value from config
+						itemEntry = ConfigUtilities.SyncConfigForItemRarityOverride(level, spawnableScrap);
 						UpdateItemRarity(level.name, spawnableScrap, itemEntry.Overrides.MoonRarities[level.name].GetValueOrDefault());
 					}
 					else {

--- a/GuysNight.LethalCompanyMod.BalancedItems/Utilities/ConfigUtilities.cs
+++ b/GuysNight.LethalCompanyMod.BalancedItems/Utilities/ConfigUtilities.cs
@@ -44,7 +44,6 @@ namespace GuysNight.LethalCompanyMod.BalancedItems.Utilities {
 			itemEntry.VanillaValues ??= new VanillaValues(gameItem.minValue, gameItem.maxValue, gameItem.weight);
 			itemEntry.Overrides ??= new OverrideProperties();
 
-			SharedComponents.ConfigFile.Reload();
 			//if weight is not added in the config, add it for future
 			//if weight is added in the config, retrieve the value and set it in the overrides
 			itemEntry.Overrides.Weight = SharedComponents.ConfigFile.Bind(SanitizeConfigEntry(Constants.ConfigSectionHeaderWeight),
@@ -85,7 +84,6 @@ namespace GuysNight.LethalCompanyMod.BalancedItems.Utilities {
 			SharedComponents.Logger.LogDebug($"Set itemEntry.VanillaValues.MoonRarities for item '{gameItem.name}' on level '{level.name}' to be '{gameItemRarity}'");
 			itemEntry.Overrides.MoonRarities.TryAdd(level.name, null);
 
-			SharedComponents.ConfigFile.Reload();
 			//if rarity for the moon is not added in the config, add it for future
 			//if it is added in the config, retrieve the value and set it in the overrides
 			itemEntry.Overrides.MoonRarities[level.name] = SharedComponents.ConfigFile.Bind(SanitizeConfigEntry(string.Format(Constants.ConfigSectionHeaderMoonRarity, level.PlanetName)),

--- a/GuysNight.LethalCompanyMod.BalancedItems/Utilities/ConfigUtilities.cs
+++ b/GuysNight.LethalCompanyMod.BalancedItems/Utilities/ConfigUtilities.cs
@@ -61,9 +61,9 @@ namespace GuysNight.LethalCompanyMod.BalancedItems.Utilities {
 				new ConfigDescription(string.Format(Constants.ConfigDescriptionAverageSellValues, gameItem.itemName, gameItemCalculatedAverageValue), new AcceptableValueRange<ushort>(ushort.MinValue, ushort.MaxValue))
 			).Value;
 
-			SharedComponents.Logger.LogInfo($"Finish adding config entries and setting override values for '{gameItem.name}' to have " +
-			                                $"average sell value = '{itemEntry.Overrides.AverageValue}', " +
-			                                $"weight = '{NumericUtilities.DenormalizeWeight(itemEntry.Overrides.Weight)}'");
+			SharedComponents.Logger.LogDebug($"Finish adding config entries and setting override values for '{gameItem.name}' to have " +
+			                                 $"average sell value = '{itemEntry.Overrides.AverageValue}', " +
+			                                 $"weight = '{NumericUtilities.DenormalizeWeight(itemEntry.Overrides.Weight)}'");
 
 			ItemsContainer.Items[gameItem.name] = itemEntry;
 
@@ -92,7 +92,7 @@ namespace GuysNight.LethalCompanyMod.BalancedItems.Utilities {
 				new ConfigDescription(string.Format(Constants.ConfigDescriptionMoonRarity, gameItem.itemName, gameItemRarity), new AcceptableValueRange<byte>(0, 100)) //100 is the max in the game
 			).Value;
 
-			SharedComponents.Logger.LogInfo($"Finish adding config entry and setting override value for '{gameItem.name}' to have rarity = '{itemEntry.Overrides.MoonRarities[level.name]}' on moon '{level.name}'");
+			SharedComponents.Logger.LogDebug($"Finish adding config entry and setting override value for '{gameItem.name}' to have rarity = '{itemEntry.Overrides.MoonRarities[level.name]}' on moon '{level.name}'");
 
 			ItemsContainer.Items[gameItem.name] = itemEntry;
 

--- a/GuysNight.LethalCompanyMod.BalancedItems/manifest.json
+++ b/GuysNight.LethalCompanyMod.BalancedItems/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "Balanced_Items",
-    "version_number": "1.4.0",
+    "version_number": "1.4.1",
     "website_url": "https://github.com/Doug-Murphy/LethalCompanyMods/tree/main/GuysNight.LethalCompanyMod.BalancedItems",
     "description": "Balanced Items is a simple mod designed to give more realistic weights and values to all of the items in Lethal Company. This mod includes item adjustments for all scrap/loot items as well as those purchasable from the terminal.",
     "dependencies": [


### PR DESCRIPTION
Performance improvements patch! Thanks to @NiranV for the report.

Resolves #20 

1. Change ConfigUtilities logs to Debug level.
2. Stop reloading config in ConfigUtilities when binding. This is far more often than needed. Only reload it once per feature now.
    - This was particularly painful when starting a session and moon rarities were being overridden.
3. Only bind config values when they would be useful. Stop binding them if the feature toggle for that feature is off.