### PR TITLE
BI: Implement Terminal Purchase Price Overrides

### DIFF
--- a/GuysNight.LethalCompanyMod.BalancedItems/Constants.cs
+++ b/GuysNight.LethalCompanyMod.BalancedItems/Constants.cs
@@ -1,20 +1,20 @@
 ﻿namespace GuysNight.LethalCompanyMod.BalancedItems {
-	public static class Constants {
-		public const string ConfigSectionHeaderToggles = "Feature Toggles";
+	internal static class Constants {
+		internal const string ConfigSectionHeaderToggles = "Feature Toggles";
 
-		public const string ConfigKeyToggleAverageSellValues = "EnableAverageSellValueOverrides";
-		public const string ConfigKeyToggleSellableEquipment = "EnableSellingEquipment";
-		public const string ConfigKeyToggleMoonRarity = "EnableMoonRarityOverrides";
-		public const string ConfigKeyToggleWeights = "EnableWeightOverrides";
+		internal const string ConfigKeyToggleAverageSellValues = "EnableAverageSellValueOverrides";
+		internal const string ConfigKeyToggleSellableEquipment = "EnableSellingEquipment";
+		internal const string ConfigKeyToggleMoonRarity = "EnableMoonRarityOverrides";
+		internal const string ConfigKeyToggleWeights = "EnableWeightOverrides";
 
-		public const string ConfigSectionHeaderAverageSellValues = "Average Sell Values";
-		public const string ConfigSectionHeaderMoonRarity = "Rarities for {0}";
-		public const string ConfigSectionHeaderWeight = "Weight";
+		internal const string ConfigSectionHeaderAverageSellValues = "Average Sell Values";
+		internal const string ConfigSectionHeaderMoonRarity = "Rarities for {0}";
+		internal const string ConfigSectionHeaderWeight = "Weight";
 
-		public const string ConfigDescriptionAverageSellValues = "The average sell value for the '{0}' item. The default vanilla value is '{1}'.";
-		public const string ConfigDescriptionMoonRarity = "The rarity for the '{0}' item. The default vanilla value is '{1}'.";
-		public const string ConfigDescriptionWeight = "The weight for the '{0}' item. The default vanilla value is '{1}'.";
+		internal const string ConfigDescriptionAverageSellValues = "The average sell value for the '{0}' item. The default vanilla value is '{1}'.";
+		internal const string ConfigDescriptionMoonRarity = "The rarity for the '{0}' item. The default vanilla value is '{1}'.";
+		internal const string ConfigDescriptionWeight = "The weight for the '{0}' item. The default vanilla value is '{1}'.";
 
-		public const double SellValueVariance = 0.2;
+		internal const double SellValueVariance = 0.2;
 	}
 }

--- a/GuysNight.LethalCompanyMod.BalancedItems/Constants.cs
+++ b/GuysNight.LethalCompanyMod.BalancedItems/Constants.cs
@@ -5,14 +5,17 @@
 		internal const string ConfigKeyToggleAverageSellValues = "EnableAverageSellValueOverrides";
 		internal const string ConfigKeyToggleSellableEquipment = "EnableSellingEquipment";
 		internal const string ConfigKeyToggleMoonRarity = "EnableMoonRarityOverrides";
+		internal const string ConfigKeyToggleTerminalPurchasePrice = "EnableTerminalPurchasePriceOverrides";
 		internal const string ConfigKeyToggleWeights = "EnableWeightOverrides";
 
 		internal const string ConfigSectionHeaderAverageSellValues = "Average Sell Values";
 		internal const string ConfigSectionHeaderMoonRarity = "Rarities for {0}";
+		internal const string ConfigSectionHeaderTerminalPurchasePrice = "Terminal Item Purchase Prices";
 		internal const string ConfigSectionHeaderWeight = "Weight";
 
 		internal const string ConfigDescriptionAverageSellValues = "The average sell value for the '{0}' item. The default vanilla value is '{1}'.";
 		internal const string ConfigDescriptionMoonRarity = "The rarity for the '{0}' item. The default vanilla value is '{1}'.";
+		internal const string ConfigDescriptionTerminalPurchasePrice = "The purchase price for the '{0}' item in the terminal. The default vanilla value is '{1}'.";
 		internal const string ConfigDescriptionWeight = "The weight for the '{0}' item. The default vanilla value is '{1}'.";
 
 		internal const double SellValueVariance = 0.2;

--- a/GuysNight.LethalCompanyMod.BalancedItems/Containers/ItemsContainer.cs
+++ b/GuysNight.LethalCompanyMod.BalancedItems/Containers/ItemsContainer.cs
@@ -1,7 +1,7 @@
 ﻿using GuysNight.LethalCompanyMod.BalancedItems.Models.Items;
 using System.Collections.Generic;
 
-namespace GuysNight.LethalCompanyMod.BalancedItems {
+namespace GuysNight.LethalCompanyMod.BalancedItems.Containers {
 	internal static class ItemsContainer {
 		internal static Dictionary<string, ItemProperties> Items { get; } = new Dictionary<string, ItemProperties> {
 			//spawned scrap items

--- a/GuysNight.LethalCompanyMod.BalancedItems/Containers/MoonsContainer.cs
+++ b/GuysNight.LethalCompanyMod.BalancedItems/Containers/MoonsContainer.cs
@@ -1,7 +1,7 @@
 ﻿using GuysNight.LethalCompanyMod.BalancedItems.Models.Moons;
 using System.Collections.Generic;
 
-namespace GuysNight.LethalCompanyMod.BalancedItems {
+namespace GuysNight.LethalCompanyMod.BalancedItems.Containers {
 	internal static class MoonsContainer {
 		internal static Dictionary<string, MoonProperties> Moons { get; } = new Dictionary<string, MoonProperties>();
 	}

--- a/GuysNight.LethalCompanyMod.BalancedItems/Containers/TerminalItemsContainer.cs
+++ b/GuysNight.LethalCompanyMod.BalancedItems/Containers/TerminalItemsContainer.cs
@@ -1,0 +1,30 @@
+﻿using GuysNight.LethalCompanyMod.BalancedItems.Models.Terminal;
+using System.Collections.Generic;
+
+namespace GuysNight.LethalCompanyMod.BalancedItems.Containers {
+	internal static class TerminalItemsContainer {
+		internal static Dictionary<string, TerminalItemProperties> TerminalItems { get; } = new Dictionary<string, TerminalItemProperties>();
+
+		internal static bool SetVanillaValuesForTerminalItem(string itemName, VanillaTerminalItemValues vanillaTerminalItemValues) {
+			if (TerminalItems.TryGetValue(itemName, out var itemEntry)) {
+				if (itemEntry.VanillaTerminalItemValues is null) {
+					itemEntry.VanillaTerminalItemValues = vanillaTerminalItemValues;
+					TerminalItems[itemName] = itemEntry;
+
+					SharedComponents.Logger.LogDebug($"Vanilla values have been set for terminal item '{itemName}' to be '{vanillaTerminalItemValues}'.");
+
+					return true;
+				}
+
+				SharedComponents.Logger.LogDebug($"Vanilla values were already set for terminal item '{itemName}' to be '{itemEntry.VanillaTerminalItemValues}'.");
+
+				return false;
+			}
+
+			TerminalItems.Add(itemName, new TerminalItemProperties(vanillaTerminalItemValues));
+			SharedComponents.Logger.LogDebug($"Created new terminal items container entry and set vanilla values for terminal item '{itemName}' to be '{vanillaTerminalItemValues}'.");
+
+			return true;
+		}
+	}
+}

--- a/GuysNight.LethalCompanyMod.BalancedItems/ItemsContainer.cs
+++ b/GuysNight.LethalCompanyMod.BalancedItems/ItemsContainer.cs
@@ -5,97 +5,97 @@ namespace GuysNight.LethalCompanyMod.BalancedItems {
 	internal static class ItemsContainer {
 		internal static Dictionary<string, ItemProperties> Items { get; } = new Dictionary<string, ItemProperties> {
 			//spawned scrap items
-			{ "7Ball", new ItemProperties(new OverrideProperties(0.5f)) },
-			{ "Airhorn", new ItemProperties(new OverrideProperties(1.5f)) },
-			{ "Bell", new ItemProperties(new OverrideProperties(5f)) },
-			{ "BigBolt", new ItemProperties(new OverrideProperties(7f)) },
+			{ "7Ball", new ItemProperties(new OverrideItemValues(0.5f)) },
+			{ "Airhorn", new ItemProperties(new OverrideItemValues(1.5f)) },
+			{ "Bell", new ItemProperties(new OverrideItemValues(5f)) },
+			{ "BigBolt", new ItemProperties(new OverrideItemValues(7f)) },
 			{ "BottleBin", new ItemProperties() },
-			{ "Brush", new ItemProperties(new OverrideProperties(1f)) },
-			{ "Candy", new ItemProperties(new OverrideProperties(1f)) },
-			{ "CashRegister", new ItemProperties(new OverrideProperties(20f)) },
-			{ "ChemicalJug", new ItemProperties(new OverrideProperties(20f)) },
-			{ "ClownHorn", new ItemProperties(new OverrideProperties(1f)) },
-			{ "Cog1", new ItemProperties(new OverrideProperties(25f)) },
-			{ "ComedyMask", new ItemProperties(new OverrideProperties(2f)) },
-			{ "Dentures", new ItemProperties(new OverrideProperties(1.5f)) },
-			{ "DiyFlashbang", new ItemProperties(new OverrideProperties(1.5f)) },
-			{ "DustPan", new ItemProperties(new OverrideProperties(1f)) },
-			{ "EggBeater", new ItemProperties(new OverrideProperties(0.5f)) },
-			{ "EnginePart1", new ItemProperties(new OverrideProperties(30f)) },
-			{ "FancyCup", new ItemProperties(new OverrideProperties(4f)) },
-			{ "FancyLamp", new ItemProperties(new OverrideProperties(10f)) },
+			{ "Brush", new ItemProperties(new OverrideItemValues(1f)) },
+			{ "Candy", new ItemProperties(new OverrideItemValues(1f)) },
+			{ "CashRegister", new ItemProperties(new OverrideItemValues(20f)) },
+			{ "ChemicalJug", new ItemProperties(new OverrideItemValues(20f)) },
+			{ "ClownHorn", new ItemProperties(new OverrideItemValues(1f)) },
+			{ "Cog1", new ItemProperties(new OverrideItemValues(25f)) },
+			{ "ComedyMask", new ItemProperties(new OverrideItemValues(2f)) },
+			{ "Dentures", new ItemProperties(new OverrideItemValues(1.5f)) },
+			{ "DiyFlashbang", new ItemProperties(new OverrideItemValues(1.5f)) },
+			{ "DustPan", new ItemProperties(new OverrideItemValues(1f)) },
+			{ "EggBeater", new ItemProperties(new OverrideItemValues(0.5f)) },
+			{ "EnginePart1", new ItemProperties(new OverrideItemValues(30f)) },
+			{ "FancyCup", new ItemProperties(new OverrideItemValues(4f)) },
+			{ "FancyLamp", new ItemProperties(new OverrideItemValues(10f)) },
 			{ "FancyPainting", new ItemProperties() },
-			{ "FishTestProp", new ItemProperties(new OverrideProperties(0.5f)) },
-			{ "FlashLaserPointer", new ItemProperties(new OverrideProperties(1f)) },
-			{ "Flask", new ItemProperties(new OverrideProperties(2f)) },
+			{ "FishTestProp", new ItemProperties(new OverrideItemValues(0.5f)) },
+			{ "FlashLaserPointer", new ItemProperties(new OverrideItemValues(1f)) },
+			{ "Flask", new ItemProperties(new OverrideItemValues(2f)) },
 			{ "GiftBox", new ItemProperties() },
-			{ "GoldBar", new ItemProperties(new OverrideProperties(27.5f)) },
+			{ "GoldBar", new ItemProperties(new OverrideItemValues(27.5f)) },
 			{ "Hairdryer", new ItemProperties() },
-			{ "LungApparatus", new ItemProperties(new OverrideProperties(50f)) },
-			{ "MagnifyingGlass", new ItemProperties(new OverrideProperties(4f)) },
-			{ "MetalSheet", new ItemProperties(new OverrideProperties(7f)) },
-			{ "MoldPan", new ItemProperties(new OverrideProperties(3f)) },
-			{ "Mug", new ItemProperties(new OverrideProperties(2f)) },
-			{ "PerfumeBottle", new ItemProperties(new OverrideProperties(0.5f)) },
+			{ "LungApparatus", new ItemProperties(new OverrideItemValues(50f)) },
+			{ "MagnifyingGlass", new ItemProperties(new OverrideItemValues(4f)) },
+			{ "MetalSheet", new ItemProperties(new OverrideItemValues(7f)) },
+			{ "MoldPan", new ItemProperties(new OverrideItemValues(3f)) },
+			{ "Mug", new ItemProperties(new OverrideItemValues(2f)) },
+			{ "PerfumeBottle", new ItemProperties(new OverrideItemValues(0.5f)) },
 			{ "Phone", new ItemProperties() },
-			{ "PickleJar", new ItemProperties(new OverrideProperties(3f)) },
-			{ "PillBottle", new ItemProperties(new OverrideProperties(1f)) },
-			{ "Remote", new ItemProperties(new OverrideProperties(1f)) },
-			{ "Ring", new ItemProperties(new OverrideProperties(0.2f)) },
-			{ "RobotToy", new ItemProperties(new OverrideProperties(5f)) },
-			{ "RubberDuck", new ItemProperties(new OverrideProperties(0.5f)) },
-			{ "SodaCanRed", new ItemProperties(new OverrideProperties(0.5f)) },
-			{ "SteeringWheel", new ItemProperties(new OverrideProperties(5f)) },
-			{ "StopSign", new ItemProperties(new OverrideProperties(6f)) },
-			{ "TeaKettle", new ItemProperties(new OverrideProperties(5f)) },
-			{ "Toothpaste", new ItemProperties(new OverrideProperties(1f)) },
-			{ "ToyCube", new ItemProperties(new OverrideProperties(1f)) },
-			{ "TragedyMask", new ItemProperties(new OverrideProperties(2f)) },
-			{ "WhoopieCushion", new ItemProperties(new OverrideProperties(0.5f)) },
-			{ "YieldSign", new ItemProperties(new OverrideProperties(6f)) },
+			{ "PickleJar", new ItemProperties(new OverrideItemValues(3f)) },
+			{ "PillBottle", new ItemProperties(new OverrideItemValues(1f)) },
+			{ "Remote", new ItemProperties(new OverrideItemValues(1f)) },
+			{ "Ring", new ItemProperties(new OverrideItemValues(0.2f)) },
+			{ "RobotToy", new ItemProperties(new OverrideItemValues(5f)) },
+			{ "RubberDuck", new ItemProperties(new OverrideItemValues(0.5f)) },
+			{ "SodaCanRed", new ItemProperties(new OverrideItemValues(0.5f)) },
+			{ "SteeringWheel", new ItemProperties(new OverrideItemValues(5f)) },
+			{ "StopSign", new ItemProperties(new OverrideItemValues(6f)) },
+			{ "TeaKettle", new ItemProperties(new OverrideItemValues(5f)) },
+			{ "Toothpaste", new ItemProperties(new OverrideItemValues(1f)) },
+			{ "ToyCube", new ItemProperties(new OverrideItemValues(1f)) },
+			{ "TragedyMask", new ItemProperties(new OverrideItemValues(2f)) },
+			{ "WhoopieCushion", new ItemProperties(new OverrideItemValues(0.5f)) },
+			{ "YieldSign", new ItemProperties(new OverrideItemValues(6f)) },
 
 			//spawned non-scrap items
-			{ "Clipboard", new ItemProperties(new OverrideProperties(0.1f)) },
-			{ "Key", new ItemProperties(new OverrideProperties(0.1f)) },
-			{ "Ragdoll", new ItemProperties(new OverrideProperties(100f)) },
-			{ "RedLocustHive", new ItemProperties(new OverrideProperties(0.5f)) },
-			{ "Shotgun", new ItemProperties(new OverrideProperties(15f)) },
-			{ "StickyNote", new ItemProperties(new OverrideProperties(0.1f)) },
+			{ "Clipboard", new ItemProperties(new OverrideItemValues(0.1f)) },
+			{ "Key", new ItemProperties(new OverrideItemValues(0.1f)) },
+			{ "Ragdoll", new ItemProperties(new OverrideItemValues(100f)) },
+			{ "RedLocustHive", new ItemProperties(new OverrideItemValues(0.5f)) },
+			{ "Shotgun", new ItemProperties(new OverrideItemValues(15f)) },
+			{ "StickyNote", new ItemProperties(new OverrideItemValues(0.1f)) },
 
 			//purchased equipment
-			{ "Boombox", new ItemProperties(new OverrideProperties(10f)) },
-			{ "ExtensionLadder", new ItemProperties(new OverrideProperties(10f)) },
-			{ "Flashlight", new ItemProperties(new OverrideProperties(2f)) },
+			{ "Boombox", new ItemProperties(new OverrideItemValues(10f)) },
+			{ "ExtensionLadder", new ItemProperties(new OverrideItemValues(10f)) },
+			{ "Flashlight", new ItemProperties(new OverrideItemValues(2f)) },
 			{ "Jetpack", new ItemProperties() },
-			{ "LockPicker", new ItemProperties(new OverrideProperties(10f)) },
-			{ "ProFlashlight", new ItemProperties(new OverrideProperties(2f)) },
+			{ "LockPicker", new ItemProperties(new OverrideItemValues(10f)) },
+			{ "ProFlashlight", new ItemProperties(new OverrideItemValues(2f)) },
 			{ "RadarBooster", new ItemProperties() },
-			{ "Shovel", new ItemProperties(new OverrideProperties(5f)) },
-			{ "SprayPaint", new ItemProperties(new OverrideProperties(1f)) },
-			{ "StunGrenade", new ItemProperties(new OverrideProperties(2f)) },
-			{ "TZPInhalant", new ItemProperties(new OverrideProperties(1f)) },
-			{ "WalkieTalkie", new ItemProperties(new OverrideProperties(2f)) },
-			{ "ZapGun", new ItemProperties(new OverrideProperties(7f)) }
+			{ "Shovel", new ItemProperties(new OverrideItemValues(5f)) },
+			{ "SprayPaint", new ItemProperties(new OverrideItemValues(1f)) },
+			{ "StunGrenade", new ItemProperties(new OverrideItemValues(2f)) },
+			{ "TZPInhalant", new ItemProperties(new OverrideItemValues(1f)) },
+			{ "WalkieTalkie", new ItemProperties(new OverrideItemValues(2f)) },
+			{ "ZapGun", new ItemProperties(new OverrideItemValues(7f)) }
 		};
 
-		internal static bool SetVanillaValuesForItem(string itemName, VanillaValues vanillaValues) {
+		internal static bool SetVanillaValuesForItem(string itemName, VanillaItemValues vanillaItemValues) {
 			if (Items.TryGetValue(itemName, out var itemEntry)) {
-				if (itemEntry.VanillaValues is null) {
-					itemEntry.VanillaValues = vanillaValues;
+				if (itemEntry.VanillaItemValues is null) {
+					itemEntry.VanillaItemValues = vanillaItemValues;
 					Items[itemName] = itemEntry;
 
-					SharedComponents.Logger.LogDebug($"Vanilla values have been set for item '{itemName}' to be '{vanillaValues}'.");
+					SharedComponents.Logger.LogDebug($"Vanilla values have been set for item '{itemName}' to be '{vanillaItemValues}'.");
 
 					return true;
 				}
 
-				SharedComponents.Logger.LogDebug($"Vanilla values were already set for item '{itemName}' to be '{itemEntry.VanillaValues}'.");
+				SharedComponents.Logger.LogDebug($"Vanilla values were already set for item '{itemName}' to be '{itemEntry.VanillaItemValues}'.");
 
 				return false;
 			}
 
-			Items.Add(itemName, new ItemProperties(vanillaValues));
-			SharedComponents.Logger.LogDebug($"Created new items container entry and set vanilla values for item '{itemName}' to be '{vanillaValues}'.");
+			Items.Add(itemName, new ItemProperties(vanillaItemValues));
+			SharedComponents.Logger.LogDebug($"Created new items container entry and set vanilla values for item '{itemName}' to be '{vanillaItemValues}'.");
 
 			return true;
 		}

--- a/GuysNight.LethalCompanyMod.BalancedItems/ItemsContainer.cs
+++ b/GuysNight.LethalCompanyMod.BalancedItems/ItemsContainer.cs
@@ -2,8 +2,8 @@
 using System.Collections.Generic;
 
 namespace GuysNight.LethalCompanyMod.BalancedItems {
-	public static class ItemsContainer {
-		public static Dictionary<string, ItemProperties> Items { get; } = new Dictionary<string, ItemProperties> {
+	internal static class ItemsContainer {
+		internal static Dictionary<string, ItemProperties> Items { get; } = new Dictionary<string, ItemProperties> {
 			//spawned scrap items
 			{ "7Ball", new ItemProperties(new OverrideProperties(0.5f)) },
 			{ "Airhorn", new ItemProperties(new OverrideProperties(1.5f)) },
@@ -78,7 +78,7 @@ namespace GuysNight.LethalCompanyMod.BalancedItems {
 			{ "ZapGun", new ItemProperties(new OverrideProperties(7f)) }
 		};
 
-		public static bool SetVanillaValuesForItem(string itemName, VanillaValues vanillaValues) {
+		internal static bool SetVanillaValuesForItem(string itemName, VanillaValues vanillaValues) {
 			if (Items.TryGetValue(itemName, out var itemEntry)) {
 				if (itemEntry.VanillaValues is null) {
 					itemEntry.VanillaValues = vanillaValues;

--- a/GuysNight.LethalCompanyMod.BalancedItems/ItemsContainer.cs
+++ b/GuysNight.LethalCompanyMod.BalancedItems/ItemsContainer.cs
@@ -1,4 +1,4 @@
-﻿using GuysNight.LethalCompanyMod.BalancedItems.Models;
+﻿using GuysNight.LethalCompanyMod.BalancedItems.Models.Items;
 using System.Collections.Generic;
 
 namespace GuysNight.LethalCompanyMod.BalancedItems {

--- a/GuysNight.LethalCompanyMod.BalancedItems/Models/Items/ItemProperties.cs
+++ b/GuysNight.LethalCompanyMod.BalancedItems/Models/Items/ItemProperties.cs
@@ -1,4 +1,4 @@
-﻿namespace GuysNight.LethalCompanyMod.BalancedItems.Models {
+﻿namespace GuysNight.LethalCompanyMod.BalancedItems.Models.Items {
 	/// <summary>
 	/// The various properties that we want to work with regarding items.
 	/// </summary>

--- a/GuysNight.LethalCompanyMod.BalancedItems/Models/Items/ItemProperties.cs
+++ b/GuysNight.LethalCompanyMod.BalancedItems/Models/Items/ItemProperties.cs
@@ -6,27 +6,27 @@
 		internal ItemProperties() {
 		}
 
-		internal ItemProperties(OverrideProperties overrideValues) {
-			OverrideValues = overrideValues;
+		internal ItemProperties(OverrideItemValues overrideItemValues) {
+			OverrideItemValues = overrideItemValues;
 		}
 
-		internal ItemProperties(VanillaValues vanillaValues) {
-			VanillaValues = vanillaValues;
+		internal ItemProperties(VanillaItemValues vanillaItemValues) {
+			VanillaItemValues = vanillaItemValues;
 		}
 
-		internal ItemProperties(VanillaValues vanillaValues, OverrideProperties overrideValues) {
-			VanillaValues = vanillaValues;
-			OverrideValues = overrideValues;
+		internal ItemProperties(VanillaItemValues vanillaItemValues, OverrideItemValues overrideItemValues) {
+			VanillaItemValues = vanillaItemValues;
+			OverrideItemValues = overrideItemValues;
 		}
 
 		/// <summary>
 		/// The overrides for this item.
 		/// </summary>
-		internal OverrideProperties OverrideValues { get; } = new OverrideProperties();
+		internal OverrideItemValues OverrideItemValues { get; } = new OverrideItemValues();
 
 		/// <summary>
 		/// The vanilla values for this item.
 		/// </summary>
-		internal VanillaValues VanillaValues { get; set; }
+		internal VanillaItemValues VanillaItemValues { get; set; }
 	}
 }

--- a/GuysNight.LethalCompanyMod.BalancedItems/Models/Items/ItemProperties.cs
+++ b/GuysNight.LethalCompanyMod.BalancedItems/Models/Items/ItemProperties.cs
@@ -2,19 +2,19 @@
 	/// <summary>
 	/// The various properties that we want to work with regarding items.
 	/// </summary>
-	public class ItemProperties {
-		public ItemProperties() {
+	internal sealed class ItemProperties {
+		internal ItemProperties() {
 		}
 
-		public ItemProperties(OverrideProperties overrideValues) {
+		internal ItemProperties(OverrideProperties overrideValues) {
 			OverrideValues = overrideValues;
 		}
 
-		public ItemProperties(VanillaValues vanillaValues) {
+		internal ItemProperties(VanillaValues vanillaValues) {
 			VanillaValues = vanillaValues;
 		}
 
-		public ItemProperties(VanillaValues vanillaValues, OverrideProperties overrideValues) {
+		internal ItemProperties(VanillaValues vanillaValues, OverrideProperties overrideValues) {
 			VanillaValues = vanillaValues;
 			OverrideValues = overrideValues;
 		}
@@ -22,11 +22,11 @@
 		/// <summary>
 		/// The overrides for this item.
 		/// </summary>
-		public OverrideProperties OverrideValues { get; } = new OverrideProperties();
+		internal OverrideProperties OverrideValues { get; } = new OverrideProperties();
 
 		/// <summary>
 		/// The vanilla values for this item.
 		/// </summary>
-		public VanillaValues VanillaValues { get; set; }
+		internal VanillaValues VanillaValues { get; set; }
 	}
 }

--- a/GuysNight.LethalCompanyMod.BalancedItems/Models/Items/OverrideItemValues.cs
+++ b/GuysNight.LethalCompanyMod.BalancedItems/Models/Items/OverrideItemValues.cs
@@ -5,20 +5,20 @@ namespace GuysNight.LethalCompanyMod.BalancedItems.Models.Items {
 	/// <summary>
 	/// Contains the data required for overriding various aspects of an item.
 	/// </summary>
-	internal sealed class OverrideProperties {
+	internal sealed class OverrideItemValues {
 		private float _weight;
 
 		/// <summary>
 		/// Default constructor for programmatically adding new overrides to our collection.
 		/// </summary>
-		internal OverrideProperties() {
+		internal OverrideItemValues() {
 		}
 
 		/// <summary>
 		/// The constructor to use when overriding only the item's weight is desired.
 		/// </summary>
 		/// <param name="weight">How much you want the item to weigh.</param>
-		internal OverrideProperties(float weight) {
+		internal OverrideItemValues(float weight) {
 			Weight = weight;
 		}
 

--- a/GuysNight.LethalCompanyMod.BalancedItems/Models/Items/OverrideProperties.cs
+++ b/GuysNight.LethalCompanyMod.BalancedItems/Models/Items/OverrideProperties.cs
@@ -1,7 +1,7 @@
 ﻿using GuysNight.LethalCompanyMod.BalancedItems.Utilities;
 using System;
 
-namespace GuysNight.LethalCompanyMod.BalancedItems.Models {
+namespace GuysNight.LethalCompanyMod.BalancedItems.Models.Items {
 	/// <summary>
 	/// Contains the data required for overriding various aspects of an item.
 	/// </summary>

--- a/GuysNight.LethalCompanyMod.BalancedItems/Models/Items/OverrideProperties.cs
+++ b/GuysNight.LethalCompanyMod.BalancedItems/Models/Items/OverrideProperties.cs
@@ -5,46 +5,46 @@ namespace GuysNight.LethalCompanyMod.BalancedItems.Models.Items {
 	/// <summary>
 	/// Contains the data required for overriding various aspects of an item.
 	/// </summary>
-	public sealed class OverrideProperties {
+	internal sealed class OverrideProperties {
 		private float _weight;
 
 		/// <summary>
 		/// Default constructor for programmatically adding new overrides to our collection.
 		/// </summary>
-		public OverrideProperties() {
+		internal OverrideProperties() {
 		}
 
 		/// <summary>
 		/// The constructor to use when overriding only the item's weight is desired.
 		/// </summary>
 		/// <param name="weight">How much you want the item to weigh.</param>
-		public OverrideProperties(float weight) {
+		internal OverrideProperties(float weight) {
 			Weight = weight;
 		}
 
 		/// <summary>
 		/// The average value of the item to override the default.
 		/// </summary>
-		public ushort AverageValue { get; set; }
+		internal ushort AverageValue { get; set; }
 
 		/// <summary>
 		/// The minimum value that the item can sell for.
 		/// </summary>
-		public int MinValue => (int)Math.Round(AverageValue - AverageValue * Constants.SellValueVariance, MidpointRounding.AwayFromZero);
+		internal int MinValue => (int)Math.Round(AverageValue - AverageValue * Constants.SellValueVariance, MidpointRounding.AwayFromZero);
 
 		/// <summary>
 		/// The maximum value that the item can sell for.
 		/// </summary>
-		public int MaxValue => (int)Math.Round(AverageValue + AverageValue * Constants.SellValueVariance, MidpointRounding.AwayFromZero);
+		internal int MaxValue => (int)Math.Round(AverageValue + AverageValue * Constants.SellValueVariance, MidpointRounding.AwayFromZero);
 
 		/// <summary>
 		/// The weight to set for the item. This value is normalized to the game's representation when setting.
 		/// </summary>
 		/// <remarks>If the desired weight is 5 pounds, the normalized representation is 1.05</remarks>
-		public float Weight {
+		internal float Weight {
 			get => _weight;
 
-			internal set {
+			set {
 				if (value < 0) {
 					throw new ArgumentOutOfRangeException(nameof(value), "You cannot set a negative weight.");
 				}

--- a/GuysNight.LethalCompanyMod.BalancedItems/Models/Items/VanillaItemValues.cs
+++ b/GuysNight.LethalCompanyMod.BalancedItems/Models/Items/VanillaItemValues.cs
@@ -1,6 +1,6 @@
 ﻿namespace GuysNight.LethalCompanyMod.BalancedItems.Models.Items {
-	internal sealed class VanillaValues {
-		internal VanillaValues(int minValue, int maxValue, float weight) {
+	internal sealed class VanillaItemValues {
+		internal VanillaItemValues(int minValue, int maxValue, float weight) {
 			MinValue = minValue;
 			MaxValue = maxValue;
 			Weight = weight;

--- a/GuysNight.LethalCompanyMod.BalancedItems/Models/Items/VanillaValues.cs
+++ b/GuysNight.LethalCompanyMod.BalancedItems/Models/Items/VanillaValues.cs
@@ -1,4 +1,4 @@
-﻿namespace GuysNight.LethalCompanyMod.BalancedItems.Models {
+﻿namespace GuysNight.LethalCompanyMod.BalancedItems.Models.Items {
 	public sealed class VanillaValues {
 		public VanillaValues(int minValue, int maxValue, float weight) {
 			MinValue = minValue;

--- a/GuysNight.LethalCompanyMod.BalancedItems/Models/Items/VanillaValues.cs
+++ b/GuysNight.LethalCompanyMod.BalancedItems/Models/Items/VanillaValues.cs
@@ -1,16 +1,16 @@
 ﻿namespace GuysNight.LethalCompanyMod.BalancedItems.Models.Items {
-	public sealed class VanillaValues {
-		public VanillaValues(int minValue, int maxValue, float weight) {
+	internal sealed class VanillaValues {
+		internal VanillaValues(int minValue, int maxValue, float weight) {
 			MinValue = minValue;
 			MaxValue = maxValue;
 			Weight = weight;
 		}
 
-		public int MinValue { get; }
+		internal int MinValue { get; }
 
-		public int MaxValue { get; }
+		internal int MaxValue { get; }
 
-		public float Weight { get; }
+		internal float Weight { get; }
 
 		public override string ToString() {
 			return $"MinValue: '{MinValue}' MaxValue: '{MaxValue}' Weight:'{Weight}'";

--- a/GuysNight.LethalCompanyMod.BalancedItems/Models/Moons/IMoonRarities.cs
+++ b/GuysNight.LethalCompanyMod.BalancedItems/Models/Moons/IMoonRarities.cs
@@ -3,7 +3,7 @@
 namespace GuysNight.LethalCompanyMod.BalancedItems.Models.Moons {
 	public interface IMoonRarities {
 		/// <summary>
-		/// The name of the moon that the rarities are for
+		/// The name of the moon that the rarities are for.
 		/// </summary>
 		public string MoonName { get; }
 

--- a/GuysNight.LethalCompanyMod.BalancedItems/Models/Moons/MoonProperties.cs
+++ b/GuysNight.LethalCompanyMod.BalancedItems/Models/Moons/MoonProperties.cs
@@ -2,19 +2,19 @@
 	/// <summary>
 	/// The various properties that we want to work with regarding moons.
 	/// </summary>
-	public class MoonProperties {
-		public MoonProperties() {
+	internal class MoonProperties {
+		internal MoonProperties() {
 		}
 
-		public MoonProperties(OverrideMoonRarities overrideMoonRarities) {
+		internal MoonProperties(OverrideMoonRarities overrideMoonRarities) {
 			OverrideMoonRarities = overrideMoonRarities;
 		}
 
-		public MoonProperties(VanillaMoonRarities vanillaMoonRarities) {
+		internal MoonProperties(VanillaMoonRarities vanillaMoonRarities) {
 			VanillaMoonRarities = vanillaMoonRarities;
 		}
 
-		public MoonProperties(VanillaMoonRarities vanillaMoonRarities, OverrideMoonRarities overrideMoonRarities) {
+		internal MoonProperties(VanillaMoonRarities vanillaMoonRarities, OverrideMoonRarities overrideMoonRarities) {
 			VanillaMoonRarities = vanillaMoonRarities;
 			OverrideMoonRarities = overrideMoonRarities;
 		}
@@ -22,11 +22,11 @@
 		/// <summary>
 		/// The overrides of the moon rarity values.
 		/// </summary>
-		public OverrideMoonRarities OverrideMoonRarities { get; set; }
+		internal OverrideMoonRarities OverrideMoonRarities { get; set; }
 
 		/// <summary>
 		/// The vanilla values of the moon rarity values.
 		/// </summary>
-		public VanillaMoonRarities VanillaMoonRarities { get; set; }
+		internal VanillaMoonRarities VanillaMoonRarities { get; set; }
 	}
 }

--- a/GuysNight.LethalCompanyMod.BalancedItems/Models/Moons/OverrideMoonRarities.cs
+++ b/GuysNight.LethalCompanyMod.BalancedItems/Models/Moons/OverrideMoonRarities.cs
@@ -4,8 +4,8 @@ namespace GuysNight.LethalCompanyMod.BalancedItems.Models.Moons {
 	/// <summary>
 	/// Used for when we want to represent override moon rarities.
 	/// </summary>
-	public class OverrideMoonRarities : IMoonRarities {
-		public OverrideMoonRarities(string moonName) {
+	internal sealed class OverrideMoonRarities : IMoonRarities {
+		internal OverrideMoonRarities(string moonName) {
 			MoonName = moonName;
 		}
 

--- a/GuysNight.LethalCompanyMod.BalancedItems/Models/Moons/VanillaMoonRarities.cs
+++ b/GuysNight.LethalCompanyMod.BalancedItems/Models/Moons/VanillaMoonRarities.cs
@@ -4,8 +4,8 @@ namespace GuysNight.LethalCompanyMod.BalancedItems.Models.Moons {
 	/// <summary>
 	/// Used for when we want to represent vanilla moon rarities.
 	/// </summary>
-	public class VanillaMoonRarities : IMoonRarities {
-		public VanillaMoonRarities(string moonName) {
+	internal sealed class VanillaMoonRarities : IMoonRarities {
+		internal VanillaMoonRarities(string moonName) {
 			MoonName = moonName;
 		}
 

--- a/GuysNight.LethalCompanyMod.BalancedItems/Models/Terminal/OverrideTerminalItemValues.cs
+++ b/GuysNight.LethalCompanyMod.BalancedItems/Models/Terminal/OverrideTerminalItemValues.cs
@@ -1,0 +1,29 @@
+﻿namespace GuysNight.LethalCompanyMod.BalancedItems.Models.Terminal {
+	/// <summary>
+	/// Contains the data required for overriding various aspects of an item in the terminal.
+	/// </summary>
+	internal sealed class OverrideTerminalItemValues {
+		/// <summary>
+		/// Default constructor for programmatically adding new overrides to our collection.
+		/// </summary>
+		internal OverrideTerminalItemValues() {
+		}
+
+		/// <summary>
+		/// The constructor to use when overriding only the item's purchase price is desired.
+		/// </summary>
+		/// <param name="purchasePrice">How much you want the item to cost in the terminal.</param>
+		internal OverrideTerminalItemValues(int purchasePrice) {
+			PurchasePrice = purchasePrice;
+		}
+
+		/// <summary>
+		/// The price of the item when buying via the terminal.
+		/// </summary>
+		internal int PurchasePrice { get; set; }
+
+		public override string ToString() {
+			return $"PurchasePrice: '{PurchasePrice}'";
+		}
+	}
+}

--- a/GuysNight.LethalCompanyMod.BalancedItems/Models/Terminal/TerminalItemProperties.cs
+++ b/GuysNight.LethalCompanyMod.BalancedItems/Models/Terminal/TerminalItemProperties.cs
@@ -1,0 +1,32 @@
+﻿namespace GuysNight.LethalCompanyMod.BalancedItems.Models.Terminal {
+	/// <summary>
+	/// The various properties that we want to work with regarding terminal items.
+	/// </summary>
+	internal sealed class TerminalItemProperties {
+		internal TerminalItemProperties() {
+		}
+
+		internal TerminalItemProperties(OverrideTerminalItemValues overrideTerminalItemValues) {
+			OverrideTerminalItemValues = overrideTerminalItemValues;
+		}
+
+		internal TerminalItemProperties(VanillaTerminalItemValues vanillaTerminalItemValues) {
+			VanillaTerminalItemValues = vanillaTerminalItemValues;
+		}
+
+		internal TerminalItemProperties(VanillaTerminalItemValues vanillaTerminalItemValues, OverrideTerminalItemValues overrideTerminalItemValues) {
+			VanillaTerminalItemValues = vanillaTerminalItemValues;
+			OverrideTerminalItemValues = overrideTerminalItemValues;
+		}
+
+		/// <summary>
+		/// The overrides for this item.
+		/// </summary>
+		internal OverrideTerminalItemValues OverrideTerminalItemValues { get; } = new OverrideTerminalItemValues();
+
+		/// <summary>
+		/// The vanilla values for this item.
+		/// </summary>
+		internal VanillaTerminalItemValues VanillaTerminalItemValues { get; set; }
+	}
+}

--- a/GuysNight.LethalCompanyMod.BalancedItems/Models/Terminal/VanillaTerminalItemValues.cs
+++ b/GuysNight.LethalCompanyMod.BalancedItems/Models/Terminal/VanillaTerminalItemValues.cs
@@ -1,0 +1,16 @@
+﻿namespace GuysNight.LethalCompanyMod.BalancedItems.Models.Terminal {
+	internal sealed class VanillaTerminalItemValues {
+		internal VanillaTerminalItemValues(int purchasePrice) {
+			PurchasePrice = purchasePrice;
+		}
+
+		/// <summary>
+		/// The price of the item when buying via the terminal.
+		/// </summary>
+		internal int PurchasePrice { get; }
+
+		public override string ToString() {
+			return $"PurchasePrice: '{PurchasePrice}'";
+		}
+	}
+}

--- a/GuysNight.LethalCompanyMod.BalancedItems/MoonsContainer.cs
+++ b/GuysNight.LethalCompanyMod.BalancedItems/MoonsContainer.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 
 namespace GuysNight.LethalCompanyMod.BalancedItems {
-	public static class MoonsContainer {
-		public static Dictionary<string, MoonProperties> Moons { get; } = new Dictionary<string, MoonProperties>();
+	internal static class MoonsContainer {
+		internal static Dictionary<string, MoonProperties> Moons { get; } = new Dictionary<string, MoonProperties>();
 	}
 }

--- a/GuysNight.LethalCompanyMod.BalancedItems/Patches/DepositItemsDeskPatches.cs
+++ b/GuysNight.LethalCompanyMod.BalancedItems/Patches/DepositItemsDeskPatches.cs
@@ -35,9 +35,9 @@ namespace GuysNight.LethalCompanyMod.BalancedItems.Patches {
 					continue;
 				}
 
-				SharedComponents.Logger.LogInfo($"Setting '{itemOnCounter.itemProperties.name}' to be sellable equipment for '{itemEntry.OverrideValues.AverageValue}' credits.");
+				SharedComponents.Logger.LogInfo($"Setting '{itemOnCounter.itemProperties.name}' to be sellable equipment for '{itemEntry.OverrideItemValues.AverageValue}' credits.");
 				itemOnCounter.itemProperties.isScrap = true;
-				itemOnCounter.scrapValue = itemEntry.OverrideValues.AverageValue;
+				itemOnCounter.scrapValue = itemEntry.OverrideItemValues.AverageValue;
 			}
 		}
 	}

--- a/GuysNight.LethalCompanyMod.BalancedItems/Patches/DepositItemsDeskPatches.cs
+++ b/GuysNight.LethalCompanyMod.BalancedItems/Patches/DepositItemsDeskPatches.cs
@@ -1,4 +1,5 @@
 ﻿#pragma warning disable S1118
+using GuysNight.LethalCompanyMod.BalancedItems.Containers;
 using HarmonyLib;
 
 namespace GuysNight.LethalCompanyMod.BalancedItems.Patches {

--- a/GuysNight.LethalCompanyMod.BalancedItems/Patches/GrabbableObjectPatches.cs
+++ b/GuysNight.LethalCompanyMod.BalancedItems/Patches/GrabbableObjectPatches.cs
@@ -43,16 +43,16 @@ namespace GuysNight.LethalCompanyMod.BalancedItems.Patches {
 				SharedComponents.ConfigFile.Reload();
 				SharedComponents.Logger.LogDebug($"Begin adding config entries and setting override values for '{__instance.itemProperties.name}'");
 				itemEntry = ConfigUtilities.SyncConfigForItemOverrides(__instance.itemProperties);
-				UpdateItemWeight(__instance, itemEntry.OverrideValues.Weight);
+				UpdateItemWeight(__instance, itemEntry.OverrideItemValues.Weight);
 			}
 			else {
-				if (itemEntry.VanillaValues is null) {
+				if (itemEntry.VanillaItemValues is null) {
 					SharedComponents.Logger.LogWarning($"Vanilla values for item '{__instance.itemProperties.name}' is null. Assuming current values are vanilla.");
-					ItemsContainer.SetVanillaValuesForItem(__instance.itemProperties.name, new VanillaValues(__instance.itemProperties.minValue, __instance.itemProperties.maxValue, __instance.itemProperties.weight));
+					ItemsContainer.SetVanillaValuesForItem(__instance.itemProperties.name, new VanillaItemValues(__instance.itemProperties.minValue, __instance.itemProperties.maxValue, __instance.itemProperties.weight));
 					itemEntry = ItemsContainer.Items[__instance.itemProperties.name];
 				}
 
-				UpdateItemWeight(__instance, itemEntry.VanillaValues!.Weight);
+				UpdateItemWeight(__instance, itemEntry.VanillaItemValues!.Weight);
 			}
 
 			SharedComponents.ConfigFile.Save();

--- a/GuysNight.LethalCompanyMod.BalancedItems/Patches/GrabbableObjectPatches.cs
+++ b/GuysNight.LethalCompanyMod.BalancedItems/Patches/GrabbableObjectPatches.cs
@@ -1,5 +1,6 @@
 ﻿#pragma warning disable	S1118
 
+using GuysNight.LethalCompanyMod.BalancedItems.Containers;
 using GuysNight.LethalCompanyMod.BalancedItems.Models.Items;
 using GuysNight.LethalCompanyMod.BalancedItems.Utilities;
 using HarmonyLib;

--- a/GuysNight.LethalCompanyMod.BalancedItems/Patches/GrabbableObjectPatches.cs
+++ b/GuysNight.LethalCompanyMod.BalancedItems/Patches/GrabbableObjectPatches.cs
@@ -1,6 +1,6 @@
 ﻿#pragma warning disable	S1118
 
-using GuysNight.LethalCompanyMod.BalancedItems.Models;
+using GuysNight.LethalCompanyMod.BalancedItems.Models.Items;
 using GuysNight.LethalCompanyMod.BalancedItems.Utilities;
 using HarmonyLib;
 

--- a/GuysNight.LethalCompanyMod.BalancedItems/Patches/LungPropPatches.cs
+++ b/GuysNight.LethalCompanyMod.BalancedItems/Patches/LungPropPatches.cs
@@ -31,7 +31,7 @@ namespace GuysNight.LethalCompanyMod.BalancedItems.Patches {
 				return;
 			}
 
-			var randomValue = RandomGenerator.Next(itemEntry.OverrideValues.MinValue, itemEntry.OverrideValues.MaxValue + 1);
+			var randomValue = RandomGenerator.Next(itemEntry.OverrideItemValues.MinValue, itemEntry.OverrideItemValues.MaxValue + 1);
 
 			__instance.SetScrapValue(randomValue);
 		}

--- a/GuysNight.LethalCompanyMod.BalancedItems/Patches/LungPropPatches.cs
+++ b/GuysNight.LethalCompanyMod.BalancedItems/Patches/LungPropPatches.cs
@@ -1,4 +1,5 @@
 ﻿#pragma warning disable S1118
+using GuysNight.LethalCompanyMod.BalancedItems.Containers;
 using HarmonyLib;
 using System;
 

--- a/GuysNight.LethalCompanyMod.BalancedItems/Patches/RoundManagerPatches.cs
+++ b/GuysNight.LethalCompanyMod.BalancedItems/Patches/RoundManagerPatches.cs
@@ -86,10 +86,10 @@ namespace GuysNight.LethalCompanyMod.BalancedItems.Patches {
 			if (isSellValueFeatureEnabled) {
 				//retrieve latest value from config
 				itemEntry = ConfigUtilities.SyncConfigForItemOverrides(spawnableScrap);
-				UpdateItemValue(spawnableScrap, itemEntry.OverrideValues.MinValue, itemEntry.OverrideValues.MaxValue);
+				UpdateItemValue(spawnableScrap, itemEntry.OverrideItemValues.MinValue, itemEntry.OverrideItemValues.MaxValue);
 			}
 			else {
-				UpdateItemValue(spawnableScrap, itemEntry.VanillaValues.MinValue, itemEntry.VanillaValues.MaxValue);
+				UpdateItemValue(spawnableScrap, itemEntry.VanillaItemValues.MinValue, itemEntry.VanillaItemValues.MaxValue);
 			}
 		}
 

--- a/GuysNight.LethalCompanyMod.BalancedItems/Patches/RoundManagerPatches.cs
+++ b/GuysNight.LethalCompanyMod.BalancedItems/Patches/RoundManagerPatches.cs
@@ -1,5 +1,6 @@
 ﻿#pragma warning disable	S1118
 
+using GuysNight.LethalCompanyMod.BalancedItems.Containers;
 using GuysNight.LethalCompanyMod.BalancedItems.Utilities;
 using HarmonyLib;
 

--- a/GuysNight.LethalCompanyMod.BalancedItems/Patches/StartOfRoundPatches.cs
+++ b/GuysNight.LethalCompanyMod.BalancedItems/Patches/StartOfRoundPatches.cs
@@ -1,5 +1,5 @@
 ﻿#pragma warning disable S1118
-using GuysNight.LethalCompanyMod.BalancedItems.Models;
+using GuysNight.LethalCompanyMod.BalancedItems.Models.Items;
 using GuysNight.LethalCompanyMod.BalancedItems.Models.Moons;
 using GuysNight.LethalCompanyMod.BalancedItems.Utilities;
 using HarmonyLib;

--- a/GuysNight.LethalCompanyMod.BalancedItems/Patches/StartOfRoundPatches.cs
+++ b/GuysNight.LethalCompanyMod.BalancedItems/Patches/StartOfRoundPatches.cs
@@ -1,4 +1,5 @@
 ﻿#pragma warning disable S1118
+using GuysNight.LethalCompanyMod.BalancedItems.Containers;
 using GuysNight.LethalCompanyMod.BalancedItems.Models.Items;
 using GuysNight.LethalCompanyMod.BalancedItems.Models.Moons;
 using GuysNight.LethalCompanyMod.BalancedItems.Utilities;

--- a/GuysNight.LethalCompanyMod.BalancedItems/Patches/StartOfRoundPatches.cs
+++ b/GuysNight.LethalCompanyMod.BalancedItems/Patches/StartOfRoundPatches.cs
@@ -36,7 +36,7 @@ namespace GuysNight.LethalCompanyMod.BalancedItems.Patches {
 				                                 $"maxValue = '{item.maxValue}', " +
 				                                 $"isScrap = '{item.isScrap}'");
 
-				ItemsContainer.SetVanillaValuesForItem(item.name, new VanillaValues(item.minValue, item.maxValue, item.weight));
+				ItemsContainer.SetVanillaValuesForItem(item.name, new VanillaItemValues(item.minValue, item.maxValue, item.weight));
 
 				ConfigUtilities.SyncConfigForItemOverrides(item);
 				if (item.name == "Key") {

--- a/GuysNight.LethalCompanyMod.BalancedItems/Patches/TerminalPatches.cs
+++ b/GuysNight.LethalCompanyMod.BalancedItems/Patches/TerminalPatches.cs
@@ -42,6 +42,8 @@ namespace GuysNight.LethalCompanyMod.BalancedItems.Patches {
 					UpdateItemPriceInShop(item, vanillaPurchasePrice);
 				}
 			}
+
+			SharedComponents.ConfigFile.Save();
 		}
 
 		private static void UpdateItemPriceInShop(Item item, int price) {

--- a/GuysNight.LethalCompanyMod.BalancedItems/Patches/TerminalPatches.cs
+++ b/GuysNight.LethalCompanyMod.BalancedItems/Patches/TerminalPatches.cs
@@ -1,22 +1,52 @@
-﻿using HarmonyLib;
+﻿#pragma warning disable S1118
+using GuysNight.LethalCompanyMod.BalancedItems.Containers;
+using GuysNight.LethalCompanyMod.BalancedItems.Models.Terminal;
+using GuysNight.LethalCompanyMod.BalancedItems.Utilities;
+using HarmonyLib;
 
 namespace GuysNight.LethalCompanyMod.BalancedItems.Patches {
 	[HarmonyPatch(typeof(Terminal))]
 	public class TerminalPatches {
+		[HarmonyPatch("Start")]
+		[HarmonyPrefix]
+		public static void InitializeTerminalItems(Terminal __instance) {
+			foreach (var item in __instance.buyableItemsList) {
+				TerminalItemsContainer.SetVanillaValuesForTerminalItem(item.name, new VanillaTerminalItemValues(item.creditsWorth));
+			}
+		}
+
 		[HarmonyPatch("BeginUsingTerminal")]
 		[HarmonyPrefix]
 		public static void SetPricesInTerminal(Terminal __instance) {
 			SharedComponents.ConfigFile.Reload();
 
-			SetItemPricesInShop(__instance);
+			var isTerminalPriceOverrideFeatureEnabled = true;
+
+			if (SharedComponents.ConfigFile.TryGetEntry<bool>(Constants.ConfigSectionHeaderToggles, Constants.ConfigKeyToggleTerminalPurchasePrice, out var featureToggleConfigEntry)) {
+				isTerminalPriceOverrideFeatureEnabled = featureToggleConfigEntry.Value;
+				SharedComponents.Logger.LogDebug($"Successfully retrieved terminal purchase price override feature toggle. Value is '{isTerminalPriceOverrideFeatureEnabled}'");
+			}
+			else {
+				SharedComponents.Logger.LogWarning("Could not retrieve terminal purchase price override feature toggle from config. Assuming it was set to true.");
+			}
+
+			foreach (var item in __instance.buyableItemsList) {
+				TerminalItemsContainer.TerminalItems[item.name] = ConfigUtilities.SyncConfigForTerminalItemOverrides(item);
+				var overridePurchasePrice = TerminalItemsContainer.TerminalItems[item.name].OverrideTerminalItemValues.PurchasePrice;
+				var vanillaPurchasePrice = TerminalItemsContainer.TerminalItems[item.name].VanillaTerminalItemValues.PurchasePrice;
+				SharedComponents.Logger.LogDebug($"For terminal item '{item.name}' the override sell price is '{overridePurchasePrice}' and the vanilla sell price is '{vanillaPurchasePrice}'");
+				if (isTerminalPriceOverrideFeatureEnabled) {
+					UpdateItemPriceInShop(item, overridePurchasePrice);
+				}
+				else {
+					UpdateItemPriceInShop(item, vanillaPurchasePrice);
+				}
+			}
 		}
 
-		private static void SetItemPricesInShop(Terminal __instance) {
-			foreach (var buyableItem in __instance.buyableItemsList) {
-				SharedComponents.Logger.LogDebug($"Found buyable item '{buyableItem.itemName}' with creditsWorth '{buyableItem.creditsWorth}' and itemName '{buyableItem.itemName}'");
-				buyableItem.creditsWorth = 10; //set price to 10
-				SharedComponents.Logger.LogDebug($"Set buyable item '{buyableItem.itemName}' creditsWorth to '{buyableItem.creditsWorth}'");
-			}
+		private static void UpdateItemPriceInShop(Item item, int price) {
+			item.creditsWorth = price;
+			SharedComponents.Logger.LogInfo($"Successfully set purchase price for '{item.itemName}' to be '{price}'");
 		}
 	}
 }

--- a/GuysNight.LethalCompanyMod.BalancedItems/Patches/TerminalPatches.cs
+++ b/GuysNight.LethalCompanyMod.BalancedItems/Patches/TerminalPatches.cs
@@ -1,0 +1,46 @@
+﻿using HarmonyLib;
+
+namespace GuysNight.LethalCompanyMod.BalancedItems.Patches {
+	[HarmonyPatch(typeof(Terminal))]
+	public class TerminalPatches {
+		[HarmonyPatch("BeginUsingTerminal")]
+		[HarmonyPrefix]
+		public static void SetPricesInTerminal(Terminal __instance) {
+			SharedComponents.ConfigFile.Reload();
+
+			SetItemPricesInShop(__instance);
+			// SetShipUpgradePricesInShop();
+		}
+
+		// [HarmonyPatch("LoadNewNodeIfAffordable")]
+		// [HarmonyPrefix]
+		// public static void LoadNewNodePrefix(TerminalNode node) {
+		// 	switch (node.name) {
+		// 		case "LoudHornBuy1":
+		// 		case "LoudHornBuyConfirm":
+		// 			node.itemCost = 5;
+		//
+		// 			break;
+		// 	}
+		//
+		// 	SharedComponents.Logger.LogDebug($"node.name = '{node.name}' node.itemCost = '{node.itemCost}' node.displayText = '{node.displayText}");
+		// }
+
+		private static void SetItemPricesInShop(Terminal __instance) {
+			foreach (var buyableItem in __instance.buyableItemsList) {
+				SharedComponents.Logger.LogDebug($"Found buyable item '{buyableItem.itemName}' with creditsWorth '{buyableItem.creditsWorth}' and itemName '{buyableItem.itemName}'");
+				buyableItem.creditsWorth = 10; //set price to 10
+				SharedComponents.Logger.LogDebug($"Set buyable item '{buyableItem.itemName}' creditsWorth to '{buyableItem.creditsWorth}'");
+			}
+		}
+
+		// private static void SetShipUpgradePricesInShop() {
+		// 	foreach (var shipUpgrade in StartOfRound.Instance.unlockablesList.unlockables) {
+		// 		SharedComponents.Logger.LogDebug($"shipUpgrade stuff -> '{shipUpgrade.unlockableName}', {shipUpgrade.unlockableType}");
+		// 		Unlockables.RegisterUnlockable(shipUpgrade, 0, StoreType.ShipUpgrade);
+		// 		Unlockables.UpdateUnlockablePrice(shipUpgrade, 5);
+		// 		SharedComponents.Logger.LogDebug($"Found ship upgrade unlockableName '{shipUpgrade.unlockableName}'");
+		// 	}
+		// }
+	}
+}

--- a/GuysNight.LethalCompanyMod.BalancedItems/Patches/TerminalPatches.cs
+++ b/GuysNight.LethalCompanyMod.BalancedItems/Patches/TerminalPatches.cs
@@ -9,22 +9,7 @@ namespace GuysNight.LethalCompanyMod.BalancedItems.Patches {
 			SharedComponents.ConfigFile.Reload();
 
 			SetItemPricesInShop(__instance);
-			// SetShipUpgradePricesInShop();
 		}
-
-		// [HarmonyPatch("LoadNewNodeIfAffordable")]
-		// [HarmonyPrefix]
-		// public static void LoadNewNodePrefix(TerminalNode node) {
-		// 	switch (node.name) {
-		// 		case "LoudHornBuy1":
-		// 		case "LoudHornBuyConfirm":
-		// 			node.itemCost = 5;
-		//
-		// 			break;
-		// 	}
-		//
-		// 	SharedComponents.Logger.LogDebug($"node.name = '{node.name}' node.itemCost = '{node.itemCost}' node.displayText = '{node.displayText}");
-		// }
 
 		private static void SetItemPricesInShop(Terminal __instance) {
 			foreach (var buyableItem in __instance.buyableItemsList) {
@@ -33,14 +18,5 @@ namespace GuysNight.LethalCompanyMod.BalancedItems.Patches {
 				SharedComponents.Logger.LogDebug($"Set buyable item '{buyableItem.itemName}' creditsWorth to '{buyableItem.creditsWorth}'");
 			}
 		}
-
-		// private static void SetShipUpgradePricesInShop() {
-		// 	foreach (var shipUpgrade in StartOfRound.Instance.unlockablesList.unlockables) {
-		// 		SharedComponents.Logger.LogDebug($"shipUpgrade stuff -> '{shipUpgrade.unlockableName}', {shipUpgrade.unlockableType}");
-		// 		Unlockables.RegisterUnlockable(shipUpgrade, 0, StoreType.ShipUpgrade);
-		// 		Unlockables.UpdateUnlockablePrice(shipUpgrade, 5);
-		// 		SharedComponents.Logger.LogDebug($"Found ship upgrade unlockableName '{shipUpgrade.unlockableName}'");
-		// 	}
-		// }
 	}
 }

--- a/GuysNight.LethalCompanyMod.BalancedItems/Plugin.cs
+++ b/GuysNight.LethalCompanyMod.BalancedItems/Plugin.cs
@@ -28,7 +28,13 @@ namespace GuysNight.LethalCompanyMod.BalancedItems {
 			SharedComponents.ConfigFile.Bind(Constants.ConfigSectionHeaderToggles,
 				Constants.ConfigKeyToggleMoonRarity,
 				true,
-				"Whether or not your specified moon rarity overrides should be applied. If set to false, vanilla values will be used. Changes to this value are reflected only after you restart your session."
+				"Whether or not your specified moon rarity overrides should be applied. If set to false, vanilla values will be used. Changes to this value are reflected at the start of each day."
+			);
+
+			SharedComponents.ConfigFile.Bind(Constants.ConfigSectionHeaderToggles,
+				Constants.ConfigKeyToggleTerminalPurchasePrice,
+				true,
+				"Whether or not your specified terminal item price overrides should be applied. If set to false, vanilla values will be used. Changes to this value are reflected every time you begin using the terminal."
 			);
 
 			SharedComponents.ConfigFile.Bind(Constants.ConfigSectionHeaderToggles,

--- a/GuysNight.LethalCompanyMod.BalancedItems/README.md
+++ b/GuysNight.LethalCompanyMod.BalancedItems/README.md
@@ -93,6 +93,15 @@ Are you annoyed that equipment items cannot be sold for any credits? Maybe you'r
 just that little bit more to meet it! You can now sell equipment items to the company! The average value you set in the
 config is the value that the equipment will sell for.
 
+## Terminal Item Purchase Prices
+
+The config values for terminal item purchase prices can be changed mid-game at any time and updates are reflected every
+time you start using the terminal.
+
+This feature gives you the power to set your own prices for items in the terminal. Want to adjust the cost of a weapon
+or a tool? No problem! Please note, this feature currently excludes ship decor and ship upgrades. Enjoy the freedom of
+customization!
+
 # Adjustments
 
 Below are the preset overrides set in this mod by default. Other properties are available to be overridden in your

--- a/GuysNight.LethalCompanyMod.BalancedItems/README.md
+++ b/GuysNight.LethalCompanyMod.BalancedItems/README.md
@@ -8,6 +8,13 @@ added!
 This mod also fixes some bugs in the game like your current carry weight being displayed as 5% greater than your actual
 carry weight.
 
+# Support
+
+If you're enjoying my mods and would like to support my work, consider making a donation. Every bit helps me continue
+creating and improving mods for Lethal Company. Thanks for your support!
+
+[![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/K3K7U4ESJ)
+
 # Configuration
 
 This mod introduces a unique approach to configuration file creation. Unlike most mods that generate their config file

--- a/GuysNight.LethalCompanyMod.BalancedItems/SharedComponents.cs
+++ b/GuysNight.LethalCompanyMod.BalancedItems/SharedComponents.cs
@@ -2,9 +2,9 @@
 using BepInEx.Logging;
 
 namespace GuysNight.LethalCompanyMod.BalancedItems {
-	public static class SharedComponents {
-		public static ManualLogSource Logger { get; set; }
+	internal static class SharedComponents {
+		internal static ManualLogSource Logger { get; set; }
 
-		public static ConfigFile ConfigFile { get; set; }
+		internal static ConfigFile ConfigFile { get; set; }
 	}
 }

--- a/GuysNight.LethalCompanyMod.BalancedItems/Utilities/ConfigUtilities.cs
+++ b/GuysNight.LethalCompanyMod.BalancedItems/Utilities/ConfigUtilities.cs
@@ -1,4 +1,5 @@
 ﻿using BepInEx.Configuration;
+using GuysNight.LethalCompanyMod.BalancedItems.Containers;
 using GuysNight.LethalCompanyMod.BalancedItems.Models.Items;
 using System;
 using System.Linq;

--- a/GuysNight.LethalCompanyMod.BalancedItems/Utilities/ConfigUtilities.cs
+++ b/GuysNight.LethalCompanyMod.BalancedItems/Utilities/ConfigUtilities.cs
@@ -40,32 +40,32 @@ namespace GuysNight.LethalCompanyMod.BalancedItems.Utilities {
 			var itemEntry = ItemsContainer.Items[gameItem.name];
 
 			//in case the current item was not in the allItemsList or otherwise not set during initialization, assume the current values from the game are vanilla and set them
-			itemEntry.VanillaValues ??= new VanillaValues(gameItem.minValue, gameItem.maxValue, gameItem.weight);
+			itemEntry.VanillaItemValues ??= new VanillaItemValues(gameItem.minValue, gameItem.maxValue, gameItem.weight);
 
 			//if weight is not added in the config, add it for future
 			//if weight is added in the config, retrieve the value and set it in the overrides
-			itemEntry.OverrideValues.Weight = SharedComponents.ConfigFile.Bind(SanitizeConfigEntry(Constants.ConfigSectionHeaderWeight),
+			itemEntry.OverrideItemValues.Weight = SharedComponents.ConfigFile.Bind(SanitizeConfigEntry(Constants.ConfigSectionHeaderWeight),
 				SanitizeConfigEntry(gameItem.name),
-				NumericUtilities.DenormalizeWeight(Math.Abs(itemEntry.OverrideValues.Weight - default(float)) > 0 ? itemEntry.OverrideValues.Weight : itemEntry.VanillaValues.Weight),
-				new ConfigDescription(string.Format(Constants.ConfigDescriptionWeight, gameItem.itemName, NumericUtilities.DenormalizeWeight(itemEntry.VanillaValues.Weight)), new AcceptableValueRange<float>(0, 1_000))
+				NumericUtilities.DenormalizeWeight(Math.Abs(itemEntry.OverrideItemValues.Weight - default(float)) > 0 ? itemEntry.OverrideItemValues.Weight : itemEntry.VanillaItemValues.Weight),
+				new ConfigDescription(string.Format(Constants.ConfigDescriptionWeight, gameItem.itemName, NumericUtilities.DenormalizeWeight(itemEntry.VanillaItemValues.Weight)), new AcceptableValueRange<float>(0, 1_000))
 			).Value;
 
 			var gameItemCalculatedAverageValue = (ushort)Math.Round(new[] { gameItem.minValue, gameItem.maxValue }.Average(), MidpointRounding.AwayFromZero);
 			//if sell value is not added in the config, add it for future
 			//if sell value is added in the config, retrieve the value and set it in the overrides
-			itemEntry.OverrideValues.AverageValue = SharedComponents.ConfigFile.Bind(SanitizeConfigEntry(Constants.ConfigSectionHeaderAverageSellValues),
+			itemEntry.OverrideItemValues.AverageValue = SharedComponents.ConfigFile.Bind(SanitizeConfigEntry(Constants.ConfigSectionHeaderAverageSellValues),
 				SanitizeConfigEntry(gameItem.name),
-				itemEntry.OverrideValues.AverageValue != default ? itemEntry.OverrideValues.AverageValue : gameItemCalculatedAverageValue,
+				itemEntry.OverrideItemValues.AverageValue != default ? itemEntry.OverrideItemValues.AverageValue : gameItemCalculatedAverageValue,
 				new ConfigDescription(string.Format(Constants.ConfigDescriptionAverageSellValues, gameItem.itemName, gameItemCalculatedAverageValue), new AcceptableValueRange<ushort>(ushort.MinValue, ushort.MaxValue))
 			).Value;
 
 			SharedComponents.Logger.LogDebug($"Finish adding config entries and setting override values for '{gameItem.name}' to have " +
-			                                 $"average sell value = '{itemEntry.OverrideValues.AverageValue}', " +
-			                                 $"weight = '{NumericUtilities.DenormalizeWeight(itemEntry.OverrideValues.Weight)}'");
+			                                 $"average sell value = '{itemEntry.OverrideItemValues.AverageValue}', " +
+			                                 $"weight = '{NumericUtilities.DenormalizeWeight(itemEntry.OverrideItemValues.Weight)}'");
 
 			ItemsContainer.Items[gameItem.name] = itemEntry;
 
-			return new ItemProperties(itemEntry.VanillaValues, itemEntry.OverrideValues);
+			return new ItemProperties(itemEntry.VanillaItemValues, itemEntry.OverrideItemValues);
 		}
 
 		internal static int SyncConfigForMoonItemRarity(SelectableLevel moon, SpawnableItemWithRarity gameItemWithRarity) {

--- a/GuysNight.LethalCompanyMod.BalancedItems/Utilities/ConfigUtilities.cs
+++ b/GuysNight.LethalCompanyMod.BalancedItems/Utilities/ConfigUtilities.cs
@@ -1,5 +1,5 @@
 ﻿using BepInEx.Configuration;
-using GuysNight.LethalCompanyMod.BalancedItems.Models;
+using GuysNight.LethalCompanyMod.BalancedItems.Models.Items;
 using System;
 using System.Linq;
 using System.Text.RegularExpressions;

--- a/GuysNight.LethalCompanyMod.BalancedItems/Utilities/ConfigUtilities.cs
+++ b/GuysNight.LethalCompanyMod.BalancedItems/Utilities/ConfigUtilities.cs
@@ -31,7 +31,7 @@ namespace GuysNight.LethalCompanyMod.BalancedItems.Utilities {
 		/// </summary>
 		/// <param name="rawEntry">The entry to sanitize.</param>
 		/// <returns></returns>
-		private static string SanitizeConfigEntry(string rawEntry) {
+		public static string SanitizeConfigEntry(string rawEntry) {
 			//replace invalid characters with '_'
 			return InvalidConfigCharsRegex.Replace(rawEntry, "_");
 		}

--- a/GuysNight.LethalCompanyMod.EodRoulette/README.md
+++ b/GuysNight.LethalCompanyMod.EodRoulette/README.md
@@ -7,6 +7,13 @@ On the desolate moons of Lethal Company, danger lurks everywhere - including rig
 landmines. With the EOD Roulette mod, you now have the power to defuse these lurking threats. But beware, this is not a
 task for the faint-hearted!
 
+# Support
+
+If you're enjoying my mods and would like to support my work, consider making a donation. Every bit helps me continue
+creating and improving mods for Lethal Company. Thanks for your support!
+
+[![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/K3K7U4ESJ)
+
 # Gameplay
 
 This mod allows players to interact with landmines in an attempt to disable them. Successful interaction will result in

--- a/GuysNight.LethalCompanyMod.InvincibleBridge/README.md
+++ b/GuysNight.LethalCompanyMod.InvincibleBridge/README.md
@@ -14,3 +14,10 @@ So why wait? Elevate your gaming experience with the Invincible Bridge Mod. Beca
 can make all the difference!
 
 Invincible Bridge Mod - For gamers who won’t let anything stand in their way. Not even a collapsing bridge. 🌉
+
+# Support
+
+If you're enjoying my mods and would like to support my work, consider making a donation. Every bit helps me continue
+creating and improving mods for Lethal Company. Thanks for your support!
+
+[![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/K3K7U4ESJ)

--- a/GuysNight.LethalCompanyMod.Terminal.Cowsay/README.md
+++ b/GuysNight.LethalCompanyMod.Terminal.Cowsay/README.md
@@ -3,6 +3,13 @@
 Welcome to the "Terminal Cowsay" mod for Lethal Company! This mod adds a fun and entertaining feature to your terminal -
 an ASCII cow that tells you Chuck Norris jokes!
 
+# Support
+
+If you're enjoying my mods and would like to support my work, consider making a donation. Every bit helps me continue
+creating and improving mods for Lethal Company. Thanks for your support!
+
+[![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/K3K7U4ESJ)
+
 # Usage
 
 Simply type `cowsay` into your terminal and hit enter. An ASCII cow will appear and tell you a Chuck Norris joke. Enjoy


### PR DESCRIPTION
1. Add new feature for Balanced Items to override terminal item purchase prices.
    - Ship upgrades and ship decor are excluded.
2. Make moon rarity overrides respect config changes each day instead of requiring restarting the session.
3. Add Ko-Fi support link to readmes.
4. Update access modifiers to be more reasonable.